### PR TITLE
Downgrade to Python 3.9

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -638,8 +638,8 @@ six = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "3512d9ac440a1aade7b6c002aeef38e90dd6f4d8be13b11c189ff903354e598a"
+python-versions = "^3.9"
+content-hash = "e2f105f6e119496fcb0ed898b48b4a62bafa7acb2e716f634a456c2fecf8c726"
 
 [metadata.files]
 appnope = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 Gooey = "^1.0.8"
 whisper = {git = "https://github.com/openai/whisper.git", rev = "8cf36f3508c9acd341a45eb2364239a3d81458b9"}
 


### PR DESCRIPTION
Folks were having issues installing deps in some environments on 3.10. We're hoping that 3.9 will work more consistently.

Resolves #10 