### PR TITLE
Adjust dark mode colors

### DIFF
--- a/stagewhisper/__main__.py
+++ b/stagewhisper/__main__.py
@@ -18,9 +18,13 @@ APPEARANCE_LIGHT = {
     'body_bg_color': '#F5F5F5',
 }
 APPEARANCE_DARK = {
+    'header_bg_color': '#222',
     'body_bg_color': '#222',
+    'footer_bg_color': '#222',
     'terminal_panel_color': '#222',
     'terminal_font_color': '#FFF',
+    'label_color': '#ffffff',
+    'help_color': '#e5e5e5'
 }
 
 
@@ -39,33 +43,33 @@ def cli():
     better hints to Gooey for how to render widgets
     """
     parser = GooeyParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    basic_group = parser.add_argument_group("Basic")
-    advanced_group = parser.add_argument_group("Advanced Options")
+    basic_group = parser.add_argument_group("Basic", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group = parser.add_argument_group("Advanced Options", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
     from whisper import available_models
 
-    basic_group.add_argument("audio", nargs="+", type=str, help="Audio file(s) to transcribe", widget="MultiFileChooser", gooey_options={'full_width': True})
-    basic_group.add_argument("--model", default="small", choices=available_models(), help="Model to use. Smaller models are more efficient, but are less accurate.")
-    advanced_group.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference",)
-    basic_group.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs", widget="DirChooser")
-    advanced_group.add_argument("--verbose", type=str2bool, default=True, help="Whether to print out the progress and debug messages")
+    basic_group.add_argument("audio", nargs="+", type=str, help="Audio file(s) to transcribe", widget="MultiFileChooser", gooey_options={**APPEARANCE_DARK, 'full_width': True} if IS_DARK else {**APPEARANCE_LIGHT, 'full_width': True})
+    basic_group.add_argument("--model", default="small", choices=available_models(), help="Model to use. Smaller models are more efficient, but are less accurate.", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    basic_group.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs", widget="DirChooser", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--verbose", type=str2bool, default=True, help="Whether to print out the progress and debug messages", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
-    advanced_group.add_argument("--task", type=str, default="transcribe", choices=["transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")
-    basic_group.add_argument("--language", type=str, default=None, choices=sorted(LANGUAGES.keys()) + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection")
+    advanced_group.add_argument("--task", type=str, default="transcribe", choices=["transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    basic_group.add_argument("--language", type=str, default=None, choices=sorted(LANGUAGES.keys()) + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
-    advanced_group.add_argument("--temperature", type=float, default=0, help="temperature to use for sampling")
-    advanced_group.add_argument("--best_of", type=optional_int, default=5, help="number of candidates when sampling with non-zero temperature")
-    advanced_group.add_argument("--beam_size", type=optional_int, default=5, help="number of beams in beam search, only applicable when temperature is zero")
-    advanced_group.add_argument("--patience", type=float, default=0.0, help="optional patience value to use in beam decoding, as in https://arxiv.org/abs/2204.05424, the default (0.0) is equivalent to not using patience")
-    advanced_group.add_argument("--length_penalty", type=float, default=None, help="optional token length penalty coefficient (alpha) as in https://arxiv.org/abs/1609.08144, uses simple lengt normalization by default")
+    advanced_group.add_argument("--temperature", type=float, default=0, help="temperature to use for sampling", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--best_of", type=optional_int, default=5, help="number of candidates when sampling with non-zero temperature", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--beam_size", type=optional_int, default=5, help="number of beams in beam search, only applicable when temperature is zero", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--patience", type=float, default=0.0, help="optional patience value to use in beam decoding, as in https://arxiv.org/abs/2204.05424, the default (0.0) is equivalent to not using patience", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--length_penalty", type=float, default=None, help="optional token length penalty coefficient (alpha) as in https://arxiv.org/abs/1609.08144, uses simple lengt normalization by default", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
-    advanced_group.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations")
-    advanced_group.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default")
+    advanced_group.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
-    advanced_group.add_argument("--temperature_increment_on_fallback", type=optional_float, default=0.2, help="temperature to increase when falling back when the decoding fails to meet either of the thresholds below")
-    advanced_group.add_argument("--compression_ratio_threshold", type=optional_float, default=2.4, help="if the gzip compression ratio is higher than this value, treat the decoding as failed")
-    advanced_group.add_argument("--logprob_threshold", type=optional_float, default=-1.0, help="if the average log probability is lower than this value, treat the decoding as failed")
-    advanced_group.add_argument("--no_speech_threshold", type=optional_float, default=0.6, help="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence")
+    advanced_group.add_argument("--temperature_increment_on_fallback", type=optional_float, default=0.2, help="temperature to increase when falling back when the decoding fails to meet either of the thresholds below", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--compression_ratio_threshold", type=optional_float, default=2.4, help="if the gzip compression ratio is higher than this value, treat the decoding as failed", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--logprob_threshold", type=optional_float, default=-1.0, help="if the average log probability is lower than this value, treat the decoding as failed", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--no_speech_threshold", type=optional_float, default=0.6, help="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
 
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")

--- a/stagewhisper/__main__.py
+++ b/stagewhisper/__main__.py
@@ -23,9 +23,11 @@ APPEARANCE_DARK = {
     'footer_bg_color': '#222',
     'terminal_panel_color': '#222',
     'terminal_font_color': '#FFF',
+}
+FIELD_COLORS_DARK = {
     'label_color': '#ffffff',
     'help_color': '#e5e5e5'
-}
+}   
 
 
 @Gooey(
@@ -43,33 +45,33 @@ def cli():
     better hints to Gooey for how to render widgets
     """
     parser = GooeyParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    basic_group = parser.add_argument_group("Basic", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group = parser.add_argument_group("Advanced Options", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    basic_group = parser.add_argument_group("Basic", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group = parser.add_argument_group("Advanced Options", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
     from whisper import available_models
 
-    basic_group.add_argument("audio", nargs="+", type=str, help="Audio file(s) to transcribe", widget="MultiFileChooser", gooey_options={**APPEARANCE_DARK, 'full_width': True} if IS_DARK else {**APPEARANCE_LIGHT, 'full_width': True})
-    basic_group.add_argument("--model", default="small", choices=available_models(), help="Model to use. Smaller models are more efficient, but are less accurate.", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    basic_group.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs", widget="DirChooser", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--verbose", type=str2bool, default=True, help="Whether to print out the progress and debug messages", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    basic_group.add_argument("audio", nargs="+", type=str, help="Audio file(s) to transcribe", widget="MultiFileChooser", gooey_options={**FIELD_COLORS_DARK, 'full_width': True} if IS_DARK else {'full_width': True})
+    basic_group.add_argument("--model", default="small", choices=available_models(), help="Model to use. Smaller models are more efficient, but are less accurate.", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    basic_group.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs", widget="DirChooser", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--verbose", type=str2bool, default=True, help="Whether to print out the progress and debug messages", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
-    advanced_group.add_argument("--task", type=str, default="transcribe", choices=["transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    basic_group.add_argument("--language", type=str, default=None, choices=sorted(LANGUAGES.keys()) + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--task", type=str, default="transcribe", choices=["transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    basic_group.add_argument("--language", type=str, default=None, choices=sorted(LANGUAGES.keys()) + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
-    advanced_group.add_argument("--temperature", type=float, default=0, help="temperature to use for sampling", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--best_of", type=optional_int, default=5, help="number of candidates when sampling with non-zero temperature", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--beam_size", type=optional_int, default=5, help="number of beams in beam search, only applicable when temperature is zero", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--patience", type=float, default=0.0, help="optional patience value to use in beam decoding, as in https://arxiv.org/abs/2204.05424, the default (0.0) is equivalent to not using patience", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--length_penalty", type=float, default=None, help="optional token length penalty coefficient (alpha) as in https://arxiv.org/abs/1609.08144, uses simple lengt normalization by default", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--temperature", type=float, default=0, help="temperature to use for sampling", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--best_of", type=optional_int, default=5, help="number of candidates when sampling with non-zero temperature", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--beam_size", type=optional_int, default=5, help="number of beams in beam search, only applicable when temperature is zero", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--patience", type=float, default=0.0, help="optional patience value to use in beam decoding, as in https://arxiv.org/abs/2204.05424, the default (0.0) is equivalent to not using patience", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--length_penalty", type=float, default=None, help="optional token length penalty coefficient (alpha) as in https://arxiv.org/abs/1609.08144, uses simple lengt normalization by default", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
-    advanced_group.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
-    advanced_group.add_argument("--temperature_increment_on_fallback", type=optional_float, default=0.2, help="temperature to increase when falling back when the decoding fails to meet either of the thresholds below", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--compression_ratio_threshold", type=optional_float, default=2.4, help="if the gzip compression ratio is higher than this value, treat the decoding as failed", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--logprob_threshold", type=optional_float, default=-1.0, help="if the average log probability is lower than this value, treat the decoding as failed", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
-    advanced_group.add_argument("--no_speech_threshold", type=optional_float, default=0.6, help="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence", gooey_options=APPEARANCE_DARK if IS_DARK else APPEARANCE_LIGHT)
+    advanced_group.add_argument("--temperature_increment_on_fallback", type=optional_float, default=0.2, help="temperature to increase when falling back when the decoding fails to meet either of the thresholds below", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--compression_ratio_threshold", type=optional_float, default=2.4, help="if the gzip compression ratio is higher than this value, treat the decoding as failed", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--logprob_threshold", type=optional_float, default=-1.0, help="if the average log probability is lower than this value, treat the decoding as failed", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
+    advanced_group.add_argument("--no_speech_threshold", type=optional_float, default=0.6, help="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence", gooey_options=FIELD_COLORS_DARK if IS_DARK else {})
 
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")


### PR DESCRIPTION
| dark | light |
| ---- | ---- |
| ![CleanShot 2022-09-26 at 18 15 46@2x](https://user-images.githubusercontent.com/5567285/192397086-35e62187-2935-4030-9922-a5f005e7509c.png) | ![CleanShot 2022-09-26 at 18 16 06@2x](https://user-images.githubusercontent.com/5567285/192397088-d74b16bb-bfdb-47ec-b174-888bce4414e2.png) |

This is not very clean code at all, but it does do the job to address #14. If you all want, I'm happy to break this isn't pieces and pass each argument only the necessary options.

It would be nice if Gooey let us declare some of this at the global level and pass it down like CSS, but I don't think that's an option.