### PR TITLE
Use backend

### DIFF
--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import isDev from 'electron-is-dev';
 
 // Packages
-import { spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { NodeCue, parseSync } from 'subtitle';
 import { v4 as uuidv4 } from 'uuid';
@@ -14,10 +14,6 @@ import { Entry, Line, Transcription } from 'knex/types/tables';
 import db, { transcriptionStatus } from '../../database/database';
 import { Channels } from '../../types/channels';
 import { WhisperArgs } from '../../types/whisperTypes';
-
-// Node
-import { ChildProcess, spawn } from 'child_process';
-import { writeFileSync } from 'fs';
 
 export type RunWhisperResponse = {
   transcription: Transcription;

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -115,6 +115,8 @@ export default ipcMain.handle(
       });
 
       // If the stdio/out/err streams are available, read them to the console
+      // Note: if `stdio` is set to anything but `"pipe"` in the `spawn` opts,
+      // then these will be undefined and these events will never fire.
       childProcess.stdout?.on('data', (data: string) => {
         console.log(`stdout: ${data}`);
       });


### PR DESCRIPTION
A first attempt to get the Electron frontend hooked up to the Python backend.

## Current status

The `run-whisper` handler successfully calls the backend Python script. Our backend script does not currently produce the VTT files that the `run-whisper` handler is expecting, so the application errors out at that point.

## For discussion

We could get this fully working by producing a VTT file the same way OpenAI's `whisper` CLI command does, but now that we have full control over the output I think we should consider what our ideal system for communication between the backend and Electron should be.

Considerations:

1. Should we write files at all or just stream everything through stdio and let node perform the desired storage and post-process manipulations?
2. What format do we want to use—for either the files or the stream? VTT? JSON? Something else?
3. How should we think about making this communication bridge extensible for when we start including additional data—such as speech diarisation?

## Usage

To test this PR:

1. Follow the instructions in the README for setting up both the `poetry` and `yarn` environments.
2. Using the app, navigate to transcribe an audio file.
3. Watch the main process console output. You should see the transcription text followed by:

   ```
   [ELECTRON] RunWhisper: Child process closed with code 0
   [ELECTRON] RunWhisper: Converting VTT to JSON...
   [ELECTRON] RunWhisper: vttPath /[snip]/stagewhisper/store/whisper/[uuid]/[audiofile].mp3.vtt
   [ELECTRON] RunWhisper: Error reading VTT file! Error: ENOENT: no such file or directory, open '/[snip]/stagewhisper/store/whisper/[uuid]/[audiofile].mp3.vtt'
   ```

   and then a bunch more error text. This is an expected error for the moment, but we should resolve it before merge, ideally.