### PR TITLE
Use backend

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
       - run: yarn install --frozen-lockfile # optional, --immutable
 
       - name: Lint Electron App
-        run: yarn lint
+        run: yarn lint:ci
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,3 @@
-name: Caching with npm
 on:
   push:
     branches:
@@ -6,57 +5,63 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
-  build:
-    name: Lint Code Base
+  electron-build:
+    name: Build and Test Electron App
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./electron
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          # - macos-latest
+          # - windows-latest
+        node_version:
+          - 17
+        architecture:
+          - x64
+          # - x86
+          # - arm64
+        # an extra windows-x86 run:
+        # include:
+        # - os: windows-2016
+        # node_version: 17
+        # architecture: x86
+    # name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile # optional, --immutable
+      - run: yarn test
+
+  electron-run-linters:
+    name: Run Electron Linters
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./electron
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
         with:
-          fetch-depth: 0
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+          node-version: 17
+
+      # ESLint and Prettier must be in `package.json`
+      - name: Install Node.js dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v2
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-
-      - name: Install dependencies
-        run:
-          npm install
-
-          # Run Linters
-      - name: Super-Linter
-        uses: github/super-linter@v4.9.7
-        env:
-          DEFAULT_BRANCH: main
-          # Only lint files in /electron/src and /electron/electron folders in format # .*src/test.*
-          FILTER_REGEX_INCLUDE: ".*electron/src/.*|.*electron/electron/.*"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.json
-          TYPESCRIPT_DEFAULT_STYLE: prettier
-          LINTER_RULES_PATH: electron
-
-      - name: List the current state of the action
-        run: "ls -la && pwd"
-
-      - name: Build
-        run: npm run build:vite
-
-      # - name: Test
-      # run: npm test
+          eslint: true
+          prettier: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        working-directory: ./electron
+        working-directory: electron
     strategy:
       matrix:
         os:
@@ -37,6 +37,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"
+          cache-dependency-path: "electron/yarn.lock"
       - run: yarn install --frozen-lockfile # optional, --immutable
       - run: yarn test
 
@@ -45,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./electron
+        working-directory: electron
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,3 +1,5 @@
+name: Integration
+
 on:
   push:
     branches:
@@ -6,9 +8,13 @@ on:
     branches:
       - main
 
+permissions:
+  checks: write
+  contents: write
+
 jobs:
-  electron-build:
-    name: Build and Test Electron App
+  electron-install:
+    name: Install and Test Electron App
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -39,30 +45,18 @@ jobs:
           cache: "yarn"
           cache-dependency-path: "electron/yarn.lock"
       - run: yarn install --frozen-lockfile # optional, --immutable
-      - run: yarn test
 
-  electron-run-linters:
-    name: Run Electron Linters
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: electron
-
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 17
-
-      # ESLint and Prettier must be in `package.json`
-      - name: Install Node.js dependencies
-        run: yarn install --frozen-lockfile
+      - name: Lint Electron App
+        run: yarn lint
 
       - name: Run linters
         uses: wearerequired/lint-action@v2
         with:
+          auto_fix: true
+          eslint_dir: electron
           eslint: true
+          prettier_dir: electron
           prettier: true
+
+      # - name: Test Electron App
+      # run: yarn test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,9 +53,9 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           auto_fix: true
-          eslint_dir: electron
+          eslint_dir: electron/
           eslint: true
-          prettier_dir: electron
+          prettier_dir: electron/
           prettier: true
 
       # - name: Test Electron App

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
 
-permissions:
-  checks: write
-  contents: write
-
 jobs:
   electron-install:
     name: Install and Test Electron App
@@ -49,14 +45,12 @@ jobs:
       - name: Lint Electron App
         run: yarn lint
 
-      - name: Run linters
-        uses: wearerequired/lint-action@v2
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always() # always run even if the previous step fails
         with:
-          auto_fix: true
-          eslint_dir: electron/
-          eslint: true
-          prettier_dir: electron/
-          prettier: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: "**/reports/eslint.xml"
 
       # - name: Test Electron App
       # run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 electron/database.db
+electron/reports

--- a/backend/stagewhisper/__main__.py
+++ b/backend/stagewhisper/__main__.py
@@ -3,6 +3,7 @@ import torch
 import whisper
 import os
 import warnings
+from whisper.utils import write_vtt
 
 @click.command()
 @click.option(
@@ -84,9 +85,9 @@ def cli(input, model, device, output_dir, verbose, task, language):
     # with open(os.path.join(output_dir, audio_basename + ".txt"), "w", encoding="utf-8") as txt:
     #     print(result["text"], file=txt)
 
-    # # save VTT
-    # with open(os.path.join(output_dir, audio_basename + ".vtt"), "w", encoding="utf-8") as vtt:
-    #     write_vtt(result["segments"], file=vtt)
+    # save VTT
+    with open(os.path.join(output_dir, audio_basename + ".vtt"), "w", encoding="utf-8") as vtt:
+        write_vtt(result["segments"], file=vtt)
     
     print(result["text"])
 

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import isDev from 'electron-is-dev';
 
 // Packages
-import { spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { NodeCue, parseSync } from 'subtitle';
 import { v4 as uuidv4 } from 'uuid';
@@ -14,10 +14,6 @@ import { Entry, Line, Transcription } from 'knex/types/tables';
 import db, { transcriptionStatus } from '../../database/database';
 import { Channels } from '../../types/channels';
 import { WhisperArgs } from '../../types/whisperTypes';
-
-// Node
-import { ChildProcess, spawn } from 'child_process';
-import { writeFileSync } from 'fs';
 
 export type RunWhisperResponse = {
   transcription: Transcription;

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from 'fs';
 import * as readline from 'node:readline';
 // Electron
 import { app, ipcMain, IpcMainInvokeEvent } from 'electron';

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -4,7 +4,6 @@ import * as readline from 'node:readline';
 import { app, ipcMain, IpcMainInvokeEvent } from 'electron';
 import { join } from 'path';
 import isDev from 'electron-is-dev';
-import isDev from 'electron-is-dev';
 
 // Packages
 import { spawn } from 'child_process';

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -106,7 +106,6 @@ export default ipcMain.handle(
         'poetry',
         ['run', 'stagewhisper', ...inputArray],
         {
-          // stdio: 'pipe',
           env,
           cwd: backendDir
         }
@@ -127,7 +126,6 @@ export default ipcMain.handle(
       // Create a line reader to read the output of the whisper script
       const lineReader = readline.createInterface({
         input: childProcess.stdout,
-        output: childProcess.stdin,
         terminal: false
       });
 

--- a/electron/electron/handlers/runWhisper/runWhisper.ts
+++ b/electron/electron/handlers/runWhisper/runWhisper.ts
@@ -115,6 +115,8 @@ export default ipcMain.handle(
       });
 
       // If the stdio/out/err streams are available, read them to the console
+      // Note: if `stdio` is set to anything but `"pipe"` in the `spawn` opts,
+      // then these will be undefined and these events will never fire.
       childProcess.stdout?.on('data', (data: string) => {
         console.log(`stdout: ${data}`);
       });

--- a/electron/electron/index.ts
+++ b/electron/electron/index.ts
@@ -105,6 +105,12 @@ app.whenReady().then(() => {
   });
 });
 
+// Handle process termination
+process.on('SIGINT', () => {
+  console.log('SIGINT: Closing application');
+  app.quit();
+});
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.

--- a/electron/package.json
+++ b/electron/package.json
@@ -26,7 +26,8 @@
     "dist": "npm run build && electron-builder",
     "pack": "npm run build && electron-builder --dir",
     "clean": "rimraf dist main src/out",
-    "type-check": "tsc",
+    "type-check": "tsc --skipLibCheck",
+    "type-check:ci": "tsc --noEmit --skipLibCheck",
     "lint": "eslint . --ext js,jsx,ts,tsx",
     "lint:fix": "eslint . --ext js,jsx,ts,tsx --fix",
     "lint:ci": "eslint . --ext js,jsx,ts,tsx  --max-warnings 0 --format junit --output-file reports/eslint.xml"

--- a/electron/package.json
+++ b/electron/package.json
@@ -28,7 +28,8 @@
     "clean": "rimraf dist main src/out",
     "type-check": "tsc",
     "lint": "eslint . --ext js,jsx,ts,tsx",
-    "lint:fix": "eslint . --ext js,jsx,ts,tsx --fix"
+    "lint:fix": "eslint . --ext js,jsx,ts,tsx --fix",
+    "lint:ci": "eslint . --ext js,jsx,ts,tsx  --max-warnings 0 --format junit --output-file reports/eslint.xml"
   },
   "dependencies": {
     "@emotion/react": "^11.10.4",

--- a/electron/src/features/debug/Debug.tsx
+++ b/electron/src/features/debug/Debug.tsx
@@ -2,14 +2,12 @@ import { ActionIcon, Affix, Button, Card, Group, Notification, Stack, Title } fr
 
 import React, { useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-// import { createDebugEntries } from '../features/entries/entrySlice';
-import { IconBug, IconBugOff, IconMoonStars, IconSun } from '@tabler/icons';
+import { IconBug, IconBugOff } from '@tabler/icons';
 import { v4 as uuidv4 } from 'uuid';
 import { selectDebugMenu, toggleDebugMenu } from '../../appSlice';
-import { getLocalFiles } from '../entries/entrySlice';
-import { toggleDarkMode } from '../settings/settingsSlice';
 import strings from '../../localization';
-import { selectDarkMode } from '../settings/settingsSlice';
+import { getLocalFiles } from '../entries/entrySlice';
+
 function Debug() {
   interface notificationType {
     id: string;
@@ -22,7 +20,7 @@ function Debug() {
 
   const dispatch = useAppDispatch();
 
-  const darkMode = useAppSelector(selectDarkMode);
+  // const darkMode = useAppSelector(selectDarkMode);
 
   const handleDeleteStore = async () => {
     try {

--- a/electron/src/features/entries/card/EntryTable.tsx
+++ b/electron/src/features/entries/card/EntryTable.tsx
@@ -6,7 +6,7 @@ import { DataTable } from 'mantine-datatable';
 import React, { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { selectAudioPadding } from '../../settings/settingsSlice';
-import { selectLines, setLines } from '../entrySlice';
+import { selectActiveLines, setLines } from '../entrySlice';
 
 function EntryTable({ audioPlayer }: { audioPlayer: Howl }) {
   // Data Table States
@@ -27,7 +27,7 @@ function EntryTable({ audioPlayer }: { audioPlayer: Howl }) {
 
   // Fetch Lines from redux store
   const dispatch = useAppDispatch();
-  const lines = useAppSelector(selectLines);
+  const lines = useAppSelector(selectActiveLines);
   const [localLines, setLocalLines] = useState<Line[]>([]);
 
   // Generate a data table using Mantine-DataTable


### PR DESCRIPTION
Reopening #104, which got closed during a rebase somehow for reasons that I'm not totally clear on 😅. Copying over the description too:

A first attempt to get the Electron frontend hooked up to the Python backend.

## Current status

The `run-whisper` handler successfully calls the backend Python script. We have made the Python backend provide a VTT file so it is a drop-in replacement for running the `whisper` CLI tool with minimal javascript changes.

In the future we would like to switch backend-electron communication to either go over stdio or use a shared database. That's reflected in the next steps below, which I will copy to a new ticket.

**Next steps:**

- [ ] update the [Python script](https://github.com/Stage-Whisper/Stage-Whisper/blob/5661a792327d0fa399e1403a10d936796c00a2f8/backend/stagewhisper/__main__.py) to provide output to stdio in a format our node process can parse and 
- [ ] update the [`runWhisper` handler](https://github.com/Stage-Whisper/Stage-Whisper/blob/5661a792327d0fa399e1403a10d936796c00a2f8/electron/electron/handlers/runWhisper/runWhisper.ts) to parse that output.

## For discussion

~We could get this fully working by producing a VTT file the same way OpenAI's `whisper` CLI command does, but now that we have full control over the output I think we should consider what our ideal system for communication between the backend and Electron should be.~

**Update:** We have decided we should stream data through stdio.

Considerations:

1. ~Should we write files at all or just stream everything through stdio and let node perform the desired storage and post-process manipulations?~ **Update:** We have decided we should stream data through stdio.
2. What format do we want to use for the stream? Plain text? VTT? JSON? Something else? (My preference would be JSON as the most extensible option.)
3. How should we think about making this communication bridge extensible for when we start including additional data—such as speech diarisation?

## Usage

To test this PR:

1. Follow the instructions in the README for setting up both the `poetry` and `yarn` environments.
2. Using the app, navigate to transcribe an audio file.
3. Watch the main process console output. You should see the transcription text followed by:

   ```
   [ELECTRON] RunWhisper: Child process closed with code 0
   [ELECTRON] RunWhisper: Converting VTT to JSON...
   [ELECTRON] RunWhisper: vttPath /[snip]/stagewhisper/store/whisper/[uuid]/[audiofile].mp3.vtt
   [ELECTRON] RunWhisper: Error reading VTT file! Error: ENOENT: no such file or directory, open '/[snip]/stagewhisper/store/whisper/[uuid]/[audiofile].mp3.vtt'
   ```

   and then a bunch more error text. This is an expected error for the moment, but we should resolve it before merge, ideally.